### PR TITLE
Fix bug in Makefile generation

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -250,7 +250,9 @@ ri-site:
 \t@-(cd docs; rdoc -R plruby.rb)
 
 test: src/$(DLLIB)
+
 EOF
+
 regexp = %r{\Atest/conv_(.*)}
 Dir["test/*"].each do |dir|
    if regexp =~ dir
@@ -260,6 +262,8 @@ Dir["test/*"].each do |dir|
      make.puts "\t-(cd #{dir} ; RUBY='#{$ruby}' sh ../runtest #{version} #{suffix})"
    end
 end
+
+make.print "\n\n.PHONY: all html rdoc ri test"
 
 make.close
 


### PR DESCRIPTION
comment from 7724be6fdd25ea4677214c98d31d99a72c2c0006

> When the Makefile is generated, we need to have the .PHONY target.
This way it will be possible to use 'make test' and not having
the make complain that 'test is up to date', as we also have
a directory named test.
