### PR TITLE
bit_or/and for PostgreSQL 9.1

### DIFF
--- a/src/conversions/bitstring/plruby_bitstring.c
+++ b/src/conversions/bitstring/plruby_bitstring.c
@@ -195,8 +195,13 @@ name_(VALUE obj, VALUE a)                                               \
 }
 
 BIT_OPERATOR(pl_bit_add, bitcat);
+#if PG_VERSION_NUM >= 90100
+BIT_OPERATOR(pl_bit_and, bit_and);
+BIT_OPERATOR(pl_bit_or, bit_or);
+#else
 BIT_OPERATOR(pl_bit_and, bitand);
 BIT_OPERATOR(pl_bit_or, bitor);
+#endif
 BIT_OPERATOR(pl_bit_xor, bitxor);
 
 static VALUE


### PR DESCRIPTION
In PostgreSQL 9.1 or above version
bitor -> bit_or
bitand -> bit_and