### PR TITLE
rename rb_frame_last_func() as rb_frame_this_func()

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -121,6 +121,14 @@ if have_func("rb_hash_delete", "ruby.h")
    $CFLAGS += " -DHAVE_RB_HASH_DELETE"
 end
 
+if have_func("rb_frame_this_func")
+   $CFLAGS += " -DHAVE_RB_FRAME_THIS_FUNC"
+end
+
+if have_func("rb_frame_last_func")
+   $CFLAGS += " -DHAVE_RB_FRAME_LAST_FUNC"
+end
+
 case version_str = `#{pg_config} --version`
 when /^PostgreSQL ([7-9])\.([0-9])(\.[0-9]+)?$/
    version = 10 * $1.to_i + $2.to_i

--- a/src/conversions/bitstring/plruby_bitstring.c
+++ b/src/conversions/bitstring/plruby_bitstring.c
@@ -182,7 +182,7 @@ name_(VALUE obj, VALUE a)                                               \
     if (TYPE(a) != T_DATA ||                                            \
         RDATA(a)->dmark != (RUBY_DATA_FUNC)pl_bit_mark) {               \
         rb_raise(rb_eArgError, "invalid argument for %s",               \
-                 rb_id2name(rb_frame_last_func()));                     \
+                 rb_id2name(rb_frame_this_func()));                     \
     }                                                                   \
     Data_Get_Struct(obj, VarBit, v0);                                   \
     Data_Get_Struct(a, VarBit, v1);                                     \
@@ -207,7 +207,7 @@ pl_bit_push(VALUE obj, VALUE a)
     if (TYPE(a) != T_DATA ||
         RDATA(a)->dmark != (RUBY_DATA_FUNC)pl_bit_mark) {
         rb_raise(rb_eArgError, "invalid argument for %s",
-                 rb_id2name(rb_frame_last_func()));
+                 rb_id2name(rb_frame_this_func()));
     }
     Data_Get_Struct(obj, VarBit, v0);
     Data_Get_Struct(a, VarBit, v1);
@@ -340,7 +340,7 @@ pl_bit_index(VALUE obj, VALUE a)
     if (TYPE(a) != T_DATA ||
         RDATA(a)->dmark != (RUBY_DATA_FUNC)pl_bit_mark) {
         rb_raise(rb_eArgError, "invalid argument for %s",
-                 rb_id2name(rb_frame_last_func()));
+                 rb_id2name(rb_frame_this_func()));
     }
     Data_Get_Struct(obj, VarBit, v0);
     Data_Get_Struct(a, VarBit, v1);

--- a/src/conversions/convcommon.h
+++ b/src/conversions/convcommon.h
@@ -8,6 +8,10 @@
 #include <ruby.h>
 #include "package.h"
 
+#if !defined(HAVE_RB_FRAME_THIS_FUNC) && defined(HAVE_RB_FRAME_LAST_FUNC)
+#define rb_frame_this_func rb_frame_last_func
+#endif
+
 #define CPY_FREE(p0_, p1_, size_) do {		\
     void *p2_ = (void *)p1_;			\
     memcpy((p0_), (p2_), (size_));		\

--- a/src/conversions/geometry/plruby_geometry.c
+++ b/src/conversions/geometry/plruby_geometry.c
@@ -254,7 +254,7 @@ NAME_(VALUE obj, VALUE a)                                       \
         if (OBJ_TAINTED(obj) || OBJ_TAINTED(a)) OBJ_TAINT(res); \
         return res;                                             \
     }                                                           \
-    return rb_funcall(a, rb_frame_last_func(), 1, obj);         \
+    return rb_funcall(a, rb_frame_this_func(), 1, obj);         \
 }
 
 POINT_CALL(pl_point_add,point_add);
@@ -590,7 +590,7 @@ pl_lseg_closest(VALUE obj, VALUE a)
             return res;
         }
     }
-    return rb_funcall(a, rb_frame_last_func(), 1, obj);
+    return rb_funcall(a, rb_frame_this_func(), 1, obj);
 }
 
 static VALUE
@@ -605,7 +605,7 @@ pl_lseg_intersect(VALUE obj, VALUE a)
         if (PLRUBY_DFC2(lseg_intersect, l0, l1)) return Qtrue;
         return Qfalse;
     }
-    return rb_funcall(a, rb_frame_last_func(), 1, obj);
+    return rb_funcall(a, rb_frame_this_func(), 1, obj);
 }
 
 static VALUE
@@ -670,15 +670,15 @@ pl_box_to_datum(VALUE obj, VALUE a)
 
     case CIRCLEOID:
         obj = pl_convert(obj, rb_intern("to_circle"), pl_circle_mark);
-        return rb_funcall(obj, rb_frame_last_func(), 1, a);
+        return rb_funcall(obj, rb_frame_this_func(), 1, a);
 
     case POLYGONOID:
         obj = pl_convert(obj, rb_intern("to_poly"), pl_poly_mark);
-        return rb_funcall(obj, rb_frame_last_func(), 1, a);
+        return rb_funcall(obj, rb_frame_this_func(), 1, a);
 
     case POINTOID:
         obj = pl_convert(obj, rb_intern("to_point"), pl_point_mark);
-        return rb_funcall(obj, rb_frame_last_func(), 1, a);
+        return rb_funcall(obj, rb_frame_this_func(), 1, a);
 
     default:
         return Qnil;
@@ -1141,11 +1141,11 @@ pl_path_to_datum(VALUE obj, VALUE a)
 
     case POLYGONOID:
         obj = pl_convert(obj, rb_intern("to_poly"), pl_poly_mark);
-        return rb_funcall(obj, rb_frame_last_func(), 1, a);
+        return rb_funcall(obj, rb_frame_this_func(), 1, a);
 
     case POINTOID:
         obj = pl_convert(obj, rb_intern("to_point"), pl_point_mark);
-        return rb_funcall(obj, rb_frame_last_func(), 1, a);
+        return rb_funcall(obj, rb_frame_this_func(), 1, a);
 
     default:
         return Qnil;
@@ -1464,19 +1464,19 @@ pl_poly_to_datum(VALUE obj, VALUE a)
 
     case CIRCLEOID:
         obj = pl_convert(obj, rb_intern("to_circle"), pl_circle_mark);
-        return rb_funcall(obj, rb_frame_last_func(), 1, a);
+        return rb_funcall(obj, rb_frame_this_func(), 1, a);
 
     case PATHOID:
         obj = pl_convert(obj, rb_intern("to_path"), pl_path_mark);
-        return rb_funcall(obj, rb_frame_last_func(), 1, a);
+        return rb_funcall(obj, rb_frame_this_func(), 1, a);
 
     case BOXOID:
         obj = pl_convert(obj, rb_intern("to_box"), pl_box_mark);
-        return rb_funcall(obj, rb_frame_last_func(), 1, a);
+        return rb_funcall(obj, rb_frame_this_func(), 1, a);
 
     case POINTOID:
         obj = pl_convert(obj, rb_intern("to_point"), pl_point_mark);
-        return rb_funcall(obj, rb_frame_last_func(), 1, a);
+        return rb_funcall(obj, rb_frame_this_func(), 1, a);
 
     default:
         return Qnil;
@@ -1746,15 +1746,15 @@ pl_circle_to_datum(VALUE obj, VALUE a)
 
     case BOXOID:
         obj = pl_convert(obj, rb_intern("to_box"), pl_box_mark);
-        return rb_funcall(obj, rb_frame_last_func(), 1, a);
+        return rb_funcall(obj, rb_frame_this_func(), 1, a);
         
     case POLYGONOID:
         obj = pl_convert(obj, rb_intern("to_poly"), pl_poly_mark);
-        return rb_funcall(obj, rb_frame_last_func(), 1, a);
+        return rb_funcall(obj, rb_frame_this_func(), 1, a);
 
     case POINTOID:
         obj = pl_convert(obj, rb_intern("to_point"), pl_point_mark);
-        return rb_funcall(obj, rb_frame_last_func(), 1, a);
+        return rb_funcall(obj, rb_frame_this_func(), 1, a);
 
     default:
         return Qnil;


### PR DESCRIPTION
for Ruby 2.2 or 2.3

Do not have any effect for older version of Ruby, of course.