### PR TITLE
ruby/st.h

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -141,6 +141,7 @@ if "aa".respond_to?(:initialize_copy, true)
 end
 
 have_func("rb_block_call")
+have_header("ruby/st.h")
 have_header("st.h")
 
 if version >= 74

--- a/src/plruby.h
+++ b/src/plruby.h
@@ -37,7 +37,9 @@
 #include "package.h"
 
 #include <ruby.h>
-#if HAVE_ST_H
+#if HAVE_RUBY_ST_H
+#include <ruby/st.h>
+#elif HAVE_ST_H
 #include <st.h>
 #endif
 


### PR DESCRIPTION
using bare "st.h" is warned 