### PR TITLE
fix safe_level_max

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -93,7 +93,13 @@ if safe = with_config("safe-level")
    end
    $CFLAGS += " -DSAFE_LEVEL=#{safe}"
 else
-   safe = 12
+   if RUBY_VERSION >= '2.3'
+      safe = 1
+   elsif RUBY_VERSION >= '2.1'
+      safe = 3
+   else
+      safe = 12
+   end
 end
 
 if with_config("greenplum")

--- a/src/plruby.h
+++ b/src/plruby.h
@@ -76,7 +76,11 @@
 extern VALUE rb_thread_list();
 
 #ifndef SAFE_LEVEL
+#ifdef RUBY_SAFE_LEVEL_MAX
+#define SAFE_LEVEL RUBY_SAFE_LEVEL_MAX
+#else
 #define SAFE_LEVEL 12
+#endif
 #endif
 
 #ifndef MAIN_SAFE_LEVEL


### PR DESCRIPTION
higher safe level than 3 does not work on Ruby 2.1 (maybe 2.0, too).
So use RUBY_SAFE_LEVEL_MAX instead of 12.